### PR TITLE
fix: Redirect oomusou.io to old-oomusou.goodjack.tw

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ lumen5.x 请看对应的分支
 - apidoc 生成在线文档 [apidocjs](http://apidocjs.com/)
 - rest api 参考规范 [jsonapi.org](http://jsonapi.org/format/)
 - api 调试工具 [postman](https://www.getpostman.com/)
-- 有用的文章 [http://oomusou.io/laravel/laravel-architecture](http://oomusou.io/laravel/laravel-architecture/)
+- 有用的文章 [https://old-oomusou.goodjack.tw/laravel/architecture](https://old-oomusou.goodjack.tw/laravel/architecture)
 - php lint [phplint](https://github.com/overtrue/phplint)
 - Laravel 理念 [From Apprentice To Artisan](https://my.oschina.net/zgldh/blog/389246)
 - 我对 REST 的理解 [http://blog.lyyw.info/2017/02/09/2017-02-09%20%E5%AF%B9rest%E7%9A%84%E7%90%86%E8%A7%A3/](http://blog.lyyw.info/2017/02/09/2017-02-09%20%E5%AF%B9rest%E7%9A%84%E7%90%86%E8%A7%A3/)


### PR DESCRIPTION
舊的 oomusou.io 文章已經轉移至 old-oomusou.goodjack.tw